### PR TITLE
Add Python 3.11 to lint matrix

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10']
+        python-version: ['3.10', '3.11']
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3


### PR DESCRIPTION
Realized in https://github.com/transitmatters/gobble/pull/9 we added Python 3.11 to the `pyproject.toml` but not the lint action