### PR TITLE
Some fixes to the cron job

### DIFF
--- a/devops/cloudformation.json
+++ b/devops/cloudformation.json
@@ -15,6 +15,10 @@
           {
             "Key": "Name",
             "Value": "gobble"
+          },
+          {
+            "Key": "service",
+            "Value": "gobble"
           }
         ],
         "BlockDeviceMappings": [

--- a/devops/playbook.yml
+++ b/devops/playbook.yml
@@ -39,4 +39,4 @@
       ansible.builtin.cron:
         name: upload todays events to s3
         minute: "0, 30"
-        job: "poetry run python3 src/s3_upload.py"
+        job: "cd /home/ubuntu/gobble && poetry run python3 src/s3_upload.py"

--- a/src/gtfs.py
+++ b/src/gtfs.py
@@ -3,18 +3,19 @@ import pandas as pd
 import pathlib
 import shutil
 import urllib.request
+from urllib.parse import urljoin
 import warnings
 
 MAIN_DIR = pathlib.Path("./data/gtfs_archives/")
 MAIN_DIR.mkdir(parents=True, exist_ok=True)
 
-GTFS_ARCHIVES_PREFIX = pathlib.Path("https://cdn.mbta.com/archive/")
+GTFS_ARCHIVES_PREFIX = "https://cdn.mbta.com/archive/"
 GTFS_ARCHIVES_FILENAME = "archived_feeds.txt"
 
 
 def _download_gtfs_archives_list():
     """Downloads list of GTFS archive urls. This file will get overwritten."""
-    archives_df = pd.read_csv(GTFS_ARCHIVES_PREFIX / GTFS_ARCHIVES_FILENAME)
+    archives_df = pd.read_csv(urljoin(GTFS_ARCHIVES_PREFIX, GTFS_ARCHIVES_FILENAME))
     archives_df.to_csv(MAIN_DIR / GTFS_ARCHIVES_FILENAME)
     return archives_df
 

--- a/src/s3_upload.py
+++ b/src/s3_upload.py
@@ -27,7 +27,7 @@ def _compress_and_upload_file(fp: str):
         buffer = BytesIO(gz_bytes)
 
         s3.upload_fileobj(
-            buffer, S3_BUCKET, Key=s3_key, ExtraArgs={"ContentType": "text/csv", "Content-Encoding": "gzip"}
+            buffer, S3_BUCKET, Key=s3_key, ExtraArgs={"ContentType": "text/csv", "ContentEncoding": "gzip"}
         )
 
 
@@ -56,5 +56,20 @@ def upload_todays_events_to_s3():
     print(f"Uploaded {len(files_updated_today)} to s3, took {end_time - start_time} seconds.")
 
 
+def backfill_events_to_s3():
+    start_time = time.time()
+
+    print("Beginning upload of all events to s3.")
+    all_events = glob.glob(str(DATA_DIR / "*/*/*/*/events.csv"))
+
+    # upload them to s3, gzipped
+    for fp in all_events:
+        _compress_and_upload_file(fp)
+
+    end_time = time.time()
+    print(f"Uploaded {len(all_events)} to s3, took {end_time - start_time} seconds.")
+
+
 if __name__ == "__main__":
-    upload_todays_events_to_s3()
+    # upload_todays_events_to_s3()
+    backfill_events_to_s3()

--- a/src/s3_upload.py
+++ b/src/s3_upload.py
@@ -56,20 +56,5 @@ def upload_todays_events_to_s3():
     print(f"Uploaded {len(files_updated_today)} to s3, took {end_time - start_time} seconds.")
 
 
-def backfill_events_to_s3():
-    start_time = time.time()
-
-    print("Beginning upload of all events to s3.")
-    all_events = glob.glob(str(DATA_DIR / "*/*/*/*/events.csv"))
-
-    # upload them to s3, gzipped
-    for fp in all_events:
-        _compress_and_upload_file(fp)
-
-    end_time = time.time()
-    print(f"Uploaded {len(all_events)} to s3, took {end_time - start_time} seconds.")
-
-
 if __name__ == "__main__":
-    # upload_todays_events_to_s3()
-    backfill_events_to_s3()
+    upload_todays_events_to_s3()


### PR DESCRIPTION
Gotta write bugs to fix bugs, thanks @devinmatte for the ansible fixes. Commandeering this draft https://github.com/transitmatters/gobble/pull/15.

Gobble was crashing on a URL pull (see stack trace,) turns out `pathlib` will truncate all instances of multiple slashes. Switching that to a regular slash--should make the service happier. 

```
ubuntu@ip-172-31-45-145:~$ journalctl --since "2023-12-07 17:13:00"
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]: Downloading GTFS bundle if necessary...
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]: No matches found in existing GTFS archives. Fetching latest archives.
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]: Traceback (most recent call last):
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]:   File "/home/ubuntu/gobble/src/gobble.py", line 106, in <module>
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]:     main()
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]:   File "/home/ubuntu/gobble/src/gobble.py", line 29, in main
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]:     scheduled_trips, scheduled_stop_times, stops = gtfs.read_gtfs(gtfs_service_date)
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]:   File "/home/ubuntu/gobble/src/gtfs.py", line 92, in read_gtfs
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]:     archive_dir = get_gtfs_archive(dateint)
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]:   File "/home/ubuntu/gobble/src/gtfs.py", line 41, in get_gtfs_archive
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]:     archives_df = _download_gtfs_archives_list()
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]:   File "/home/ubuntu/gobble/src/gtfs.py", line 17, in _download_gtfs_archives_list
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]:     archives_df = pd.read_csv(GTFS_ARCHIVES_PREFIX / GTFS_ARCHIVES_FILENAME)
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]:   File "/home/ubuntu/.cache/pypoetry/virtualenvs/gobble-i42h0hpV-py3.10/lib/python3.10/site-packages/pandas/io/parsers/readers.py", lin>
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]:     return _read(filepath_or_buffer, kwds)
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]:   File "/home/ubuntu/.cache/pypoetry/virtualenvs/gobble-i42h0hpV-py3.10/lib/python3.10/site-packages/pandas/io/parsers/readers.py", lin>
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]:     parser = TextFileReader(filepath_or_buffer, **kwds)
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]:   File "/home/ubuntu/.cache/pypoetry/virtualenvs/gobble-i42h0hpV-py3.10/lib/python3.10/site-packages/pandas/io/parsers/readers.py", lin>
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]:     self._engine = self._make_engine(f, self.engine)
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]:   File "/home/ubuntu/.cache/pypoetry/virtualenvs/gobble-i42h0hpV-py3.10/lib/python3.10/site-packages/pandas/io/parsers/readers.py", lin>
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]:     self.handles = get_handle(
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]:   File "/home/ubuntu/.cache/pypoetry/virtualenvs/gobble-i42h0hpV-py3.10/lib/python3.10/site-packages/pandas/io/common.py", line 718, in>
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]:     ioargs = _get_filepath_or_buffer(
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]:   File "/home/ubuntu/.cache/pypoetry/virtualenvs/gobble-i42h0hpV-py3.10/lib/python3.10/site-packages/pandas/io/common.py", line 372, in>
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]:     with urlopen(req_info) as req:
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]:   File "/home/ubuntu/.cache/pypoetry/virtualenvs/gobble-i42h0hpV-py3.10/lib/python3.10/site-packages/pandas/io/common.py", line 274, in>
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]:     return urllib.request.urlopen(*args, **kwargs)
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]:   File "/usr/lib/python3.10/urllib/request.py", line 216, in urlopen
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]:     return opener.open(url, data, timeout)
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]:   File "/usr/lib/python3.10/urllib/request.py", line 516, in open
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]:     req = meth(req)
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]:   File "/usr/lib/python3.10/urllib/request.py", line 1272, in do_request_
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]:     raise URLError('no host given')
Dec 07 17:13:00 ip-172-31-45-145 poetry[138534]: urllib.error.URLError: <urlopen error no host given>
Dec 07 17:13:00 ip-172-31-45-145 systemd[1]: gobble.service: Main process exited, code=exited, status=1/FAILURE
Dec 07 17:13:00 ip-172-31-45-145 systemd[1]: gobble.service: Failed with result 'exit-code'.
```