### PR TITLE
[hack] try to kill old gobble service

### DIFF
--- a/devops/systemd.conf
+++ b/devops/systemd.conf
@@ -10,7 +10,8 @@ WorkingDirectory=/home/ubuntu/gobble
 ExecStart=/home/ubuntu/.local/bin/poetry run python3 src/gobble.py
 Restart=on-failure
 RestartSec=5s
-
+StartLimitIntervalSec=1d
+StartLimitBurst=5
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Looks like an old version of the gobble service is still running. You can tell this by looking at old journalctl logs and seeing:

```
Dec 12 17:11:00 ip-172-31-45-145 systemd[1]: gobble.service: Scheduled restart job, restart counter is at 94274.
Dec 12 17:11:00 ip-172-31-45-145 systemd[1]: Stopped gobble.
Dec 12 17:11:00 ip-172-31-45-145 systemd[1]: gobble.service: Consumed 1.036s CPU time.
Dec 12 17:11:00 ip-172-31-45-145 systemd[1]: Started gobble.
// traceback......
Dec 12 17:11:01 ip-172-31-45-145 poetry[456316]:     archives_df = pd.read_csv(GTFS_ARCHIVES_PREFIX / GTFS_ARCHIVES_FILENAME)
// traceback.......
Dec 12 17:11:01 ip-172-31-45-145 systemd[1]: gobble.service: Main process exited, code=exited, status=1/FAILURE
Dec 12 17:11:01 ip-172-31-45-145 systemd[1]: gobble.service: Failed with result 'exit-code'.
Dec 12 17:11:01 ip-172-31-45-145 systemd[1]: gobble.service: Consumed 1.082s CPU time.
Dec 12 17:11:04 ip-172-31-45-145 sshd[456320]: Invalid user postmaster from 43.134.63.194 port 56072
Dec 12 17:11:04 ip-172-31-45-145 sshd[456320]: Received disconnect from 43.134.63.194 port 56072:11: Bye Bye [preauth]
Dec 12 17:11:04 ip-172-31-45-145 sshd[456320]: Disconnected from invalid user postmaster 43.134.63.194 port 56072 [preauth]
Dec 12 17:11:06 ip-172-31-45-145 systemd[1]: gobble.service: Scheduled restart job, restart counter is at 94275.
Dec 12 17:11:06 ip-172-31-45-145 systemd[1]: Stopped gobble.
```

This service is still referring to old code! I've tried killing the old process via `systemctl stop` and a couple of other jank commands but to no avail. This pr pushes up some nonsense a la https://serverfault.com/questions/1079789/systemd-limit-the-number-of-times-a-service-can-restart to see if the old service will die if I tweak some systemd settings. This should, in theory, limit the number of restarts the service can have in a day before dying for good. 