### PR TITLE
Fixing the deploy and linting for 3.12

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    env:
+      DD_API_KEY: ${{ secrets.DD_API_KEY }}
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.10', '3.11']
+        python-version: ['3.10', '3.11', '3.12']
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ black = "^23.7.0"
 
 [tool.black]
 line-length = 120
-target-version = ['py310', 'py311']
+target-version = ['py310', 'py311', 'py312']
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
Fixing the deploy so that we properly access the DD_API_KEY (oops)

Also deploy happens on Python 3.12, so we should lint on 3.12 as well