### PR TITLE
Only pull relevant columns from gtfs stops

### DIFF
--- a/src/gtfs.py
+++ b/src/gtfs.py
@@ -26,7 +26,7 @@ def _download_gtfs_archives_list():
     return archives_df
 
 
-def to_dateint(date):
+def to_dateint(date: datetime.date):
     """turn date into 20220615 e.g."""
     return int(str(date).replace("-", ""))
 

--- a/src/gtfs.py
+++ b/src/gtfs.py
@@ -12,6 +12,12 @@ MAIN_DIR.mkdir(parents=True, exist_ok=True)
 GTFS_ARCHIVES_PREFIX = "https://cdn.mbta.com/archive/"
 GTFS_ARCHIVES_FILENAME = "archived_feeds.txt"
 
+# defining these columns in particular becasue we use them everywhere
+RTE_DIR_STOP = ["route_id", "direction_id", "stop_id"]
+
+# only fetch required columns from gtfs csv's to reduce memory usage
+STOP_TIMES_COLS = ["stop_id", "trip_id", "arrival_time", "departure_time", "stop_id", "stop_sequence"]
+
 
 def _download_gtfs_archives_list():
     """Downloads list of GTFS archive urls. This file will get overwritten."""
@@ -100,8 +106,7 @@ def read_gtfs(date: datetime.date):
     stops = pd.read_csv(archive_dir / "stops.txt")
 
     stop_times = pd.read_csv(
-        archive_dir / "stop_times.txt",
-        dtype={"trip_id": str, "stop_id": str, "stop_headsign": str, "checkpoint_id": str},
+        archive_dir / "stop_times.txt", dtype={"trip_id": str, "stop_id": str}, usecols=STOP_TIMES_COLS
     )
     stop_times = stop_times[stop_times.trip_id.isin(trips.trip_id)]
     stop_times.arrival_time = pd.to_timedelta(stop_times.arrival_time)
@@ -120,10 +125,6 @@ def add_gtfs_headways(events_df: pd.DataFrame, all_trips: pd.DataFrame, all_stop
     https://pandas.pydata.org/docs/reference/api/pandas.merge_asof.html
     """
     # TODO: I think we need to worry about 114/116/117 headways?
-
-    # defining these columns in particular becasue we use them everywhere
-    RTE_DIR_STOP = ["route_id", "direction_id", "stop_id"]
-
     results = []
     # NB: event times are converted to pd timestamps in this fuction for pandas merge manipulation,
     # but will be converted back into datetime.datetime for serialization purposes. careful!


### PR DESCRIPTION
The GTFS stop times dataframe can take as much as >1.2 gigs in memory if we pull all of it (varies per gtfs package.)The actual `.txt` it's based off of only needs ~160 MB 🙃 

Only reading in the useful columns takes our usage down from 1.2 gigs to ~0.86, and is filtered down to an eighth of that after later filtering. 


**We might need to shrink this usage down even further later on: an approach here if we keep OOM-ing would be to first stream through the file with a more lightweight file reader, identify the # rows which contain the trips we care about, then feed those rows indices into the `skiprows` arg. Is this a nightmare? Is pandas a nightmare? Are we in a nightmare? 