### PR TITLE
Skip loading state if JSON is corrupted

### DIFF
--- a/src/disk.py
+++ b/src/disk.py
@@ -45,6 +45,9 @@ def read_state():
             return json.load(fd)
     except FileNotFoundError:
         return {}
+    except json.decoder.JSONDecodeError:
+        print("Encountered corrupted state, will skip loading.")
+        return {}
 
 
 def write_state(state):

--- a/src/gobble.py
+++ b/src/gobble.py
@@ -66,7 +66,7 @@ def main():
                 gtfs_service_date = service_date
                 scheduled_trips, scheduled_stop_times, stops = gtfs.read_gtfs(gtfs_service_date)
 
-            if prev["stop_id"] in STOPS.get(route_id, {}) or True:
+            if prev["stop_id"] in STOPS.get(route_id, {}):
                 print(f"[{updated_at.isoformat()}] Event: route={route_id} trip_id={trip_id} DEP stop={stop_name_prev}")
 
                 # write the event here


### PR DESCRIPTION
Current state file is truncated--we shouldn't attempt to load a file like this when this happens, and not loading it won't degrade the service. Will also try to find out whats going on there. 