### PR TITLE
intuit arrivals from v3 api

### DIFF
--- a/src/gobble.py
+++ b/src/gobble.py
@@ -93,7 +93,7 @@ def main():
 
             if stop_id in STOPS.get(route_id, {}):
                 logger.info(
-                    f"[{updated_at.isoformat()}] Event: route={route_id} trip_id={trip_id} DEP stop={stop_name_prev}"
+                    f"[{updated_at.isoformat()}] Event: route={route_id} trip_id={trip_id} {event_type} stop={stop_name_prev}"
                 )
 
                 # write the event here

--- a/src/gobble.py
+++ b/src/gobble.py
@@ -91,7 +91,10 @@ def main():
                 gtfs_service_date = service_date
                 scheduled_trips, scheduled_stop_times, stops = gtfs.read_gtfs(gtfs_service_date)
 
-            if prev["stop_id"] in STOPS.get(route_id, {}):
+            if is_departure_event:
+                stop_id = prev["stop_id"]
+
+            if stop_id in STOPS.get(route_id, {}):
                 logger.info(
                     f"[{updated_at.isoformat()}] Event: route={route_id} trip_id={trip_id} DEP stop={stop_name_prev}"
                 )
@@ -104,7 +107,7 @@ def main():
                             "route_id": route_id,
                             "trip_id": trip_id,
                             "direction_id": direction_id,
-                            "stop_id": prev["stop_id"],
+                            "stop_id": stop_id,
                             "stop_sequence": current_stop_sequence,
                             "vehicle_id": "0",  # TODO??
                             "vehicle_label": vehicle_label,

--- a/src/gobble.py
+++ b/src/gobble.py
@@ -79,7 +79,10 @@ def main():
         is_arrival_event = current_status == "STOPPED_AT" and prev.get("event_type", event_type) == "DEP"
 
         if is_departure_event or is_arrival_event:
-            stop_name_prev = get_stop_name(stops, prev["stop_id"])
+            if is_departure_event:
+                stop_id = prev["stop_id"]
+
+            stop_name = get_stop_name(stops, stop_id)
             service_date = util.service_date(updated_at)
 
             # refresh the gtfs data bundle if the day has incremented
@@ -88,12 +91,9 @@ def main():
                 gtfs_service_date = service_date
                 scheduled_trips, scheduled_stop_times, stops = gtfs.read_gtfs(gtfs_service_date)
 
-            if is_departure_event:
-                stop_id = prev["stop_id"]
-
             if stop_id in STOPS.get(route_id, {}):
                 logger.info(
-                    f"[{updated_at.isoformat()}] Event: route={route_id} trip_id={trip_id} {event_type} stop={stop_name_prev}"
+                    f"[{updated_at.isoformat()}] Event: route={route_id} trip_id={trip_id} {event_type} stop={stop_name}"
                 )
 
                 # write the event here

--- a/src/gobble.py
+++ b/src/gobble.py
@@ -79,9 +79,6 @@ def main():
         is_arrival_event = current_status == "STOPPED_AT" and prev.get("event_type", event_type) == "DEP"
 
         if is_departure_event or is_arrival_event:
-            logger.info(
-                f"{trip_id} current_stop_sequence: {current_stop_sequence}: {current_status}===stop: {stop_id}, prev: {prev['stop_id']}"
-            )
             stop_name_prev = get_stop_name(stops, prev["stop_id"])
             service_date = util.service_date(updated_at)
 


### PR DESCRIPTION
Use the `current_status` signal to capture arrivals so that we can keep track of dwell times and travel times in addition to headways. (Note that this isn't a problem for scheduled headways b/c the schedule doesn't distinguish arrival and departure times.)

Ran it for a couple of single trips with some aggressive logging to yield something like this...

```
INFO:repos/gobble/src/gobble.py:60168633 current_stop_sequence: 3: STOPPED_AT    | stop: 2, prev: 1
INFO:repos/gobble/src/gobble.py:60168633 current_stop_sequence: 4: IN_TRANSIT_TO | stop: 6, prev: 2
INFO:repos/gobble/src/gobble.py:60168633 current_stop_sequence: 4: STOPPED_AT    | stop: 6, prev: 6
INFO:repos/gobble/src/gobble.py:60168633 current_stop_sequence: 5: IN_TRANSIT_TO | stop: 10003, prev: 6
INFO:repos/gobble/src/gobble.py:60168633 current_stop_sequence: 5: STOPPED_AT    | stop: 10003, prev: 10003
INFO:repos/gobble/src/gobble.py:60168633 current_stop_sequence: 6: IN_TRANSIT_TO | stop: 57, prev: 10003
INFO:repos/gobble/src/gobble.py:60168633 current_stop_sequence: 6: STOPPED_AT    | stop: 57, prev: 57
INFO:repos/gobble/src/gobble.py:60168633 current_stop_sequence: 7: IN_TRANSIT_TO | stop: 58, prev: 57
INFO:repos/gobble/src/gobble.py:60168633 current_stop_sequence: 7: STOPPED_AT    | stop: 58, prev: 58
INFO:repos/gobble/src/gobble.py:60168633 current_stop_sequence: 8: IN_TRANSIT_TO | stop: 10590, prev: 58
```
So now we're getting us a neat little alternating arrival/departure pattern (where `STOPPED_AT` is arrival, and `IN_TRANSIT_TO` is departure.)

A question about off-by-ones:
As of now, 
* A departure's `stop_id` it's PREVIOUS stop, and its `stop_sequence` is its CURRENT STOP SEQUENCE
In this pr, I add that
* An arrival's `stop_id` is the CURRENT stop, and its `stop_sequence` is its CURRENT STOP SEQUENCE

Does this sound right to yall? Will be annoying to debug if it's pushed incorrectly. 