### PR TITLE
use service date for s3 uploads, save as UTC

### DIFF
--- a/src/disk.py
+++ b/src/disk.py
@@ -27,7 +27,7 @@ DATA_DIR = pathlib.Path("data")
 STATE_FILENAME = "state.json"
 
 
-def write_event(event):
+def write_event(event: dict):
     dirname = DATA_DIR / pathlib.Path(
         output_dir_path(
             event["route_id"],
@@ -47,7 +47,7 @@ def write_event(event):
 
 
 @tracer.wrap()
-def read_state():
+def read_state() -> dict:
     pathname = pathlib.Path(DATA_DIR) / STATE_FILENAME
     try:
         with pathname.open() as fd:
@@ -60,7 +60,7 @@ def read_state():
 
 
 @tracer.wrap()
-def write_state(state):
+def write_state(state: dict):
     DATA_DIR.mkdir(parents=True, exist_ok=True)
     pathname = pathlib.Path(DATA_DIR) / STATE_FILENAME
 

--- a/src/gobble.py
+++ b/src/gobble.py
@@ -94,7 +94,7 @@ def main():
 
             if stop_id in STOPS.get(route_id, {}):
                 logger.info(
-                    f"[{updated_at.isoformat()}] Event: route={route_id} {direction_id} {stop_id} trip_id={trip_id} {event_type} stop={stop_name}"
+                    f"[{updated_at.isoformat()}] Event: route={route_id} trip_id={trip_id} {event_type} stop={stop_name}"
                 )
 
                 # write the event here

--- a/src/gobble.py
+++ b/src/gobble.py
@@ -117,7 +117,7 @@ def main():
                 )
 
                 headway_adjusted_df = gtfs.add_gtfs_headways(df, scheduled_trips, scheduled_stop_times)
-                # convert event_time from a local pandas timesamp to a UTC python datetime for serialization purposes
+                # convert event_time from a local pandas timestamp to a UTC python datetime for serialization purposes
                 headway_adjusted_df["event_time"] = headway_adjusted_df["event_time"].dt.tz_convert(None)  # to UTC
                 # future warning: returning a series is actually the correct future behavior of to_pydatetime(), can drop the
                 # context manager later

--- a/src/gtfs.py
+++ b/src/gtfs.py
@@ -134,15 +134,15 @@ def add_gtfs_headways(events_df: pd.DataFrame, all_trips: pd.DataFrame, all_stop
     https://pandas.pydata.org/docs/reference/api/pandas.merge_asof.html
     This function is ADAPTED from historical bus headway calculations
     https://github.com/transitmatters/t-performance-dash/blob/ebecaca071b39d8140296545f2e5b287915bc60d/server/bus/gtfs_archive.py#L90
+
+    NB 1: event times are converted to pd timestamps in this fuction for pandas merge manipulation,
+    but will be converted back into datetime.datetime for serialization purposes. careful!
+    NB 2: while live events' and the scheduled stop times' timestamps are reported in local (eastern) time,
+    the MBTA monthly datadumps report their times in UTC. our calculations are in
+    local time, but our final product should be converted to UTC for parity. careful!!!!!
     """
     # TODO: I think we need to worry about 114/116/117 headways?
     results = []
-    # NB: event times are converted to pd timestamps in this fuction for pandas merge manipulation,
-    # but will be converted back into datetime.datetime for serialization purposes. careful!
-    # NB: while live events' and the scheduled stop times' timestamps are reported in local (eastern) time,
-    # the MBTA monthly datadumps report their times in UTC. our calculations are in
-    # local time, but our final product should be converted to UTC for parity. careful!!!!!
-    events_df.event_time = events_df["event_time"]
 
     # we have to do this day-by-day because gtfs changes so often
     for service_date, days_events in events_df.groupby("service_date"):

--- a/src/s3_upload.py
+++ b/src/s3_upload.py
@@ -55,7 +55,7 @@ def upload_todays_events_to_s3():
     pull_date = service_date(fortyfive_min_ago)
 
     # get files updated for this service date
-    # TODO: only update modified files? cant imagine much of a difference if we partition live data day
+    # TODO: only update modified files? cant imagine much of a difference if we partition live data by day
     files_updated_today = glob.glob(
         LOCAL_DATA_TEMPLATE.format(year=pull_date.year, month=pull_date.month, day=pull_date.day)
     )

--- a/src/s3_upload.py
+++ b/src/s3_upload.py
@@ -44,15 +44,12 @@ def _compress_and_upload_file(fp: str):
 def upload_todays_events_to_s3():
     """Upload today's events to the TM s3 bucket.
 
-    This is assumed to run on a 30 minute schedule, and as such we start the job from 45 minutes prior
     TODO: This process will work just as well for busses and CR, just need to update the local data/S3 key accordingly
     """
     start_time = time.time()
 
     logger.info("Beginning upload of recent events to s3.")
-    fortyfive_min_ago = datetime.datetime.now() - datetime.timedelta(minutes=45)
-    # the service date for 4am-midnight is the previous day
-    pull_date = service_date(fortyfive_min_ago)
+    pull_date = service_date(datetime.datetime.now())
 
     # get files updated for this service date
     # TODO: only update modified files? cant imagine much of a difference if we partition live data by day

--- a/src/s3_upload.py
+++ b/src/s3_upload.py
@@ -55,7 +55,7 @@ def upload_todays_events_to_s3():
     pull_date = service_date(fortyfive_min_ago)
 
     # get files updated for this service date
-    # TODO: only update modified files? cant imagine much of a difference if we partition by day
+    # TODO: only update modified files? cant imagine much of a difference if we partition live data day
     files_updated_today = glob.glob(
         LOCAL_DATA_TEMPLATE.format(year=pull_date.year, month=pull_date.month, day=pull_date.day)
     )

--- a/src/util.py
+++ b/src/util.py
@@ -5,12 +5,12 @@ import os
 EASTERN_TIME = ZoneInfo("America/New_York")
 
 
-def to_dateint(date: date):
+def to_dateint(date: date) -> int:
     """turn date into 20220615 e.g."""
     return int(str(date).replace("-", ""))
 
 
-def output_dir_path(route_id: str, direction_id: str, stop_id: str, ts: datetime):
+def output_dir_path(route_id: str, direction_id: str, stop_id: str, ts: datetime) -> str:
     date = service_date(ts)
 
     return os.path.join(


### PR DESCRIPTION
various date changes!

1. we were looks at current date, not service date, for data uploads. for s3 upload jobs run between midnight and 4am, we should be looking to the previous day etc. 
2. the realtime API reports local time, whereas the monthly MBTA CSV's are in UTC. we'll convert the gobble event times to UTC as well. 
3. also a couple more type annos because we love our future selves.

fun fact! its call `tz_convert` because you feel like youve been taken to the twilight zone <3 