### PR TITLE
Always use `main` for deployments

### DIFF
--- a/devops/playbook.yml
+++ b/devops/playbook.yml
@@ -8,6 +8,7 @@
       git:
         repo: https://github.com/transitmatters/gobble.git
         dest: /home/ubuntu/gobble
+        version: main
         force: yes
 
     - name: install poetry


### PR DESCRIPTION
Sometimes when testing changes, I'd deploy a branch. So when the redeploy happens in CI, it doesn't return to main. We should ensure deploys happen from the main branch