### PR TITLE
add rapid transit to gobble

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -240,7 +240,6 @@ BUS_STOPS = {
 
 ROUTES_BUS = set(BUS_STOPS.keys())
 
-# TODO: add appropriate disk/s3 upload utilities
 ROUTES_CR = {
     "CR-Fairmount",
     "CR-Fitchburg",
@@ -256,3 +255,15 @@ ROUTES_CR = {
     "CR-Providence",
     "CR-Foxboro",
 }
+
+ROUTES_RAPID = {
+    "Red",
+    "Blue",
+    "Orange",
+    "Green-B",
+    "Green-C",
+    "Green-D",
+    "Green-E",
+}
+
+ALL_ROUTES = ROUTES_BUS.union(ROUTES_CR).union(ROUTES_RAPID)

--- a/src/event.py
+++ b/src/event.py
@@ -5,7 +5,7 @@ import logging
 from ddtrace import tracer
 import warnings
 
-from constants import BUS_STOPS, ROUTES_CR
+from constants import BUS_STOPS, ROUTES_CR, ROUTES_RAPID
 import gtfs
 import disk
 import util
@@ -129,8 +129,8 @@ def process_event(
             gtfs_service_date = service_date
             scheduled_trips, scheduled_stop_times, stops = gtfs.read_gtfs(gtfs_service_date)
 
-        # store all commuter rail stops, but only some bus stops
-        if stop_id and (route_id in ROUTES_CR or stop_id in BUS_STOPS.get(route_id, {})):
+        # store all commuter rail/subway stops, but only some bus stops
+        if route_id in ROUTES_CR.union(ROUTES_RAPID) or stop_id in BUS_STOPS.get(route_id, {}):
             logger.info(
                 f"[{updated_at.isoformat()}] Event: route={route_id} trip_id={trip_id} {event_type} stop={stop_name}"
             )

--- a/src/gobble.py
+++ b/src/gobble.py
@@ -6,7 +6,7 @@ import sseclient
 import logging
 from ddtrace import tracer
 
-from constants import ROUTES_BUS, ROUTES_CR
+from constants import ALL_ROUTES
 from config import CONFIG
 from event import process_event
 from logger import set_up_logging
@@ -19,7 +19,7 @@ tracer.enabled = CONFIG["DATADOG_TRACE_ENABLED"]
 
 API_KEY = CONFIG["mbta"]["v3_api_key"]
 HEADERS = {"X-API-KEY": API_KEY, "Accept": "text/event-stream"}
-URL = f'https://api-v3.mbta.com/vehicles?filter[route]={",".join(ROUTES_CR.union(ROUTES_BUS))}'
+URL = f'https://api-v3.mbta.com/vehicles?filter[route]={",".join(ALL_ROUTES)}'
 
 
 def main():

--- a/src/util.py
+++ b/src/util.py
@@ -2,7 +2,7 @@ from datetime import date, datetime, timedelta
 from zoneinfo import ZoneInfo
 import os
 
-from constants import ROUTES_CR
+from constants import ROUTES_CR, ROUTES_RAPID
 
 EASTERN_TIME = ZoneInfo("US/Eastern")
 
@@ -16,9 +16,15 @@ def output_dir_path(route_id: str, direction_id: str, stop_id: str, ts: datetime
     date = service_date(ts)
 
     # commuter rail lines have dashes in both route id and stop id, so use underscores as delimiter
+    # ex, CR-Fairmount_0_DB-2205-01/
     if route_id in ROUTES_CR:
         delimiter = "_"
         mode = "cr"
+    # rapid transit may rarely have dashes AND SPACES in stop id/route id!
+    # ex, Green_D_1-Union Square-02
+    elif route_id in ROUTES_RAPID:
+        delimiter = "_"
+        mode = "rapid"
     else:
         delimiter = "-"
         mode = "bus"


### PR DESCRIPTION
adding rapid transit to gobble ingests real quick. you can peep sample data uploaded via `s3_upload.py` at `s3://tm-mbta-performance/Events-live/daily-rapid-data/`

some notes:
* we store event info for all stops on all subway lines. is there a subset we should be using instead?
* note that the s3 file structure doesnt match that of the performance API s3 data: general structure is something like `Events-live/daily-rapid-data/Green-B_0_70117/Year=...`
* The Union Square GL has a weird stop ID that introduces spaces into the s3 path, zoinks scoob 