### PR TITLE
configure loggers across all files explicitly 

### DIFF
--- a/src/disk.py
+++ b/src/disk.py
@@ -4,9 +4,13 @@ import os
 import pathlib
 from util import output_dir_path
 from ddtrace import tracer
-import logging
 
-logger = logging.getLogger(__name__)
+from config import CONFIG
+from logger import set_up_logging
+
+
+logger = set_up_logging(__name__)
+tracer.enabled = CONFIG["DATADOG_TRACE_ENABLED"]
 
 CSV_FILENAME = "events.csv"
 CSV_FIELDS = [

--- a/src/event.py
+++ b/src/event.py
@@ -47,12 +47,13 @@ def reduce_update_event(update):
 
     try:
         # The vehicle’s current (when current_status is STOPPED_AT) or next stop.
-        if "stop" in update["relationships"]:
-            stop_id = update["relationships"]["stop"]["data"]["id"]
-        else:
-            stop_id = None
-    except TypeError:
-        logger.error(f"Encountered TypeError when processing update: {update}")
+        stop_id = update["relationships"]["stop"]["data"]["id"]
+    except (TypeError, KeyError):
+        logger.error(
+            f"Encountered degenerate stop information. This event will be skipped: {update}",
+            stack_info=True,
+            exc_info=True,
+        )
         stop_id = None
 
     return (
@@ -105,7 +106,6 @@ def process_event(
         prev["updated_at"] = datetime.fromisoformat(prev["updated_at"])
 
     if stop_id is None:
-        logger.info(f"Skipping event with no stop_id: {update}")
         return
 
     is_departure_event, is_arrival_event = arr_or_dep_event(

--- a/src/event.py
+++ b/src/event.py
@@ -2,16 +2,19 @@ import json
 from datetime import date, datetime
 from typing import Tuple
 import pandas as pd
-import logging
 from ddtrace import tracer
 import warnings
 
+from config import CONFIG
 from constants import BUS_STOPS, ROUTES_CR, ROUTES_RAPID
-import gtfs
 import disk
+import gtfs
+from logger import set_up_logging
 import util
 
-logger = logging.getLogger(__name__)
+logger = set_up_logging(__name__)
+tracer.enabled = CONFIG["DATADOG_TRACE_ENABLED"]
+
 
 EVENT_TYPE_MAP = {
     # use the first instance of this signal as departure

--- a/src/event.py
+++ b/src/event.py
@@ -1,3 +1,4 @@
+import json
 from datetime import date, datetime
 from typing import Tuple
 import pandas as pd
@@ -50,7 +51,7 @@ def reduce_update_event(update):
         stop_id = update["relationships"]["stop"]["data"]["id"]
     except (TypeError, KeyError):
         logger.error(
-            f"Encountered degenerate stop information. This event will be skipped: {update}",
+            f"Encountered degenerate stop information. This event will be skipped: {json.dumps(update)}",
             stack_info=True,
             exc_info=True,
         )

--- a/src/gtfs.py
+++ b/src/gtfs.py
@@ -6,9 +6,14 @@ import urllib.request
 from urllib.parse import urljoin
 from ddtrace import tracer
 from typing import List, Tuple
-import logging
 
-logger = logging.getLogger(__name__)
+from config import CONFIG
+from logger import set_up_logging
+
+
+logger = set_up_logging(__name__)
+tracer.enabled = CONFIG["DATADOG_TRACE_ENABLED"]
+
 
 MAIN_DIR = pathlib.Path("./data/gtfs_archives/")
 MAIN_DIR.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
each logger needs to be configured on a per-file basis. so does ddtracing--disabling that locally as well.