### PR TITLE
fix: Always deploy to current EC2 instance in stack

### DIFF
--- a/devops/deploy.sh
+++ b/devops/deploy.sh
@@ -27,7 +27,10 @@ aws cloudformation deploy --stack-name $STACK_NAME \
     --capabilities CAPABILITY_NAMED_IAM \
     --no-fail-on-empty-changeset
 
-INSTANCE_HOSTNAME=$(aws cloudformation describe-stacks --stack-name $STACK_NAME --query "Stacks[0].Outputs[?OutputKey=='InstanceHostname'].OutputValue" --output text)
+# Look up the physical ID of the EC2 instance currently associated with the stack
+INSTANCE_PHYSICAL_ID=$(aws cloudformation list-stack-resources --stack-name $STACK_NAME --query "StackResourceSummaries[?LogicalResourceId=='GBLEInstance'].PhysicalResourceId" --output text)
+# Look up the hostname of the instance by physical ID
+INSTANCE_HOSTNAME=$(aws ec2 describe-instances --instance-ids $INSTANCE_PHYSICAL_ID --query "Reservations[*].Instances[*].PublicDnsName" --output text)
 
 # Run the playbook! :-)
 export ANSIBLE_HOST_KEY_CHECKING=False # If it's a new host, ssh known_hosts not having the key fingerprint will cause an error. Silence it


### PR DESCRIPTION
Today we manually restarted the EC2 instance assigned to Gobble and it got a new public Internet address.

This breaks our deploy script because it's reading from `aws cloudformation describe-stacks` which contains the output from CloudFormation when it originally queried the instance. If we want, we can get the current instance address like this:

- Look up the physical ID of the EC2 instance by its logical ID (which is statically known from `cloudformation.json`)
- Look up the DNS address of the instance by physical ID

_Test plan:_

I ran `deploy.sh` locally and verified that it was able to connect to the EC2 instance (well, uh, _an_ EC2 instance). We'll probably have to try it on GH Actions to be 100% sure.