### PR TITLE
Tag volumes of EC2 instances

### DIFF
--- a/devops/cloudformation.json
+++ b/devops/cloudformation.json
@@ -71,6 +71,7 @@
         "IamInstanceProfile" : {
           "Ref" : "S3BucketsInstanceProfile"
         },
+        "PropagateTagsToVolumeOnCreation": true,
         "SecurityGroupIds": [
           {
             "Ref": "GBLESecurityGroup"


### PR DESCRIPTION
In order to add the service tag to the EC2 volume, we need this property

This will help with cost tracking