### PR TITLE
Update on a schedule instead of on merge to avoid missing data

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,9 @@
 name: deploy
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+  schedule:
+    - cron: '30 7 * * *' # 3:15AM EST every day
 
 jobs:
   deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: deploy
 on:
   workflow_dispatch:
   schedule:
-    - cron: '30 7 * * *' # 3:15AM EST every day
+    - cron: '30 7 * * *' # 3:30AM EST every day
 
 jobs:
   deploy:


### PR DESCRIPTION
Since any amount of downtime for gobble means missing data, we should update during morning windows or with a manual deploy