### PR TITLE
Rename all rapid output directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # gobble
-![lint](https://github.com/transitmatters/gobble/workflows/lint/badge.svg?branch=main)
-![test](https://github.com/transitmatters/gobble/workflows/test/badge.svg?branch=main)
+![lint](https://github.com/transitmatters/gobble/actions/workflows/lint.yml/badge.svg?branch=main)
+![test](https://github.com/transitmatters/gobble/actions/workflows/test.yml/badge.svg?branch=main)
 
 ![Screenshot in action](docs/screenshot.png)
 

--- a/devops/playbook.yml
+++ b/devops/playbook.yml
@@ -80,6 +80,7 @@
       tags:
         - "git.repository_url:github.com/transitmatters/gobble"
         - "git.commit.sha:{{ lookup('env', 'GIT_SHA') }}"
+        - "version:{{ lookup('env', 'GIT_SHA') }}"
       apm_config:
         enabled: true
       process_config:

--- a/src/util.py
+++ b/src/util.py
@@ -19,19 +19,20 @@ def output_dir_path(route_id: str, direction_id: str, stop_id: str, ts: datetime
     # ex, CR-Fairmount_0_DB-2205-01/
     if route_id in ROUTES_CR:
         delimiter = "_"
+        stop_path = f"{route_id}{delimiter}{direction_id}{delimiter}{stop_id}"
         mode = "cr"
-    # rapid transit may rarely have dashes AND SPACES in stop id/route id!
-    # ex, Green_D_1-Union Square-02
+    # rapid transit doesn't need to be split by direction or line
     elif route_id in ROUTES_RAPID:
-        delimiter = "_"
+        stop_path = f"{stop_id}"
         mode = "rapid"
     else:
         delimiter = "-"
+        stop_path = f"{route_id}{delimiter}{direction_id}{delimiter}{stop_id}"
         mode = "bus"
 
     return os.path.join(
         f"daily-{mode}-data",
-        f"{route_id}{delimiter}{direction_id}{delimiter}{stop_id}",
+        stop_path,
         f"Year={date.year}",
         f"Month={date.month}",
         f"Day={date.day}",


### PR DESCRIPTION
Renames the rapid transit directory to not include the route or direction since they're not needed (also make using them on the dashboard harder)

Fixes #81 

When merging we'll want to rename the existing dirs, but we can always do it after for the older files

We don't _need_ gobble for rapid transit since we have LAMP but we should still have it in case LAMP ever goes down or proves to be unreliable, so we should make it easily readable by the dashboard