### PR TITLE
Add mattapan trolley ID to the list

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -694,6 +694,7 @@ ROUTES_RAPID = {
     "Green-C",
     "Green-D",
     "Green-E",
+    "Mattapan"
 }
 
 ALL_ROUTES = ROUTES_BUS.union(ROUTES_CR).union(ROUTES_RAPID)

--- a/src/constants.py
+++ b/src/constants.py
@@ -686,15 +686,6 @@ ROUTES_CR = {
     "CR-Foxboro",
 }
 
-ROUTES_RAPID = {
-    "Red",
-    "Blue",
-    "Orange",
-    "Green-B",
-    "Green-C",
-    "Green-D",
-    "Green-E",
-    "Mattapan"
-}
+ROUTES_RAPID = {"Red", "Blue", "Orange", "Green-B", "Green-C", "Green-D", "Green-E", "Mattapan"}
 
 ALL_ROUTES = ROUTES_BUS.union(ROUTES_CR).union(ROUTES_RAPID)


### PR DESCRIPTION
Fixes #77 

Based on the guidance given in #86 i *think* this is all thats needed? I seem to be seeing Mattapan events in the feed after adding this so I assume this is all I need to do

![Screenshot_20240629_165933](https://github.com/transitmatters/gobble/assets/17362949/af523928-9b0c-443f-867e-75313358a4e3)
