### PR TITLE
Added vehicle_consist (#101)

### DIFF
--- a/src/disk.py
+++ b/src/disk.py
@@ -25,6 +25,7 @@ CSV_FIELDS = [
     "event_time",
     "scheduled_headway",
     "scheduled_tt",
+    "vehicle_consist",
 ]
 DATA_DIR = pathlib.Path("data")
 STATE_FILENAME = "state.json"

--- a/src/event.py
+++ b/src/event.py
@@ -53,6 +53,10 @@ def reduce_update_event(update: dict) -> Tuple:
     current_status = update["attributes"]["current_status"]
     event_type = EVENT_TYPE_MAP[current_status]
     updated_at = datetime.fromisoformat(update["attributes"]["updated_at"])
+    if len(update["attributes"]["carriages"]) > 0:
+        vehicle_consist = "|".join([carriage["label"] for carriage in update["attributes"]["carriages"]])
+    else:
+        vehicle_consist = update["attributes"]["label"]
 
     try:
         # The vehicle’s current (when current_status is STOPPED_AT) or next stop.
@@ -71,6 +75,7 @@ def reduce_update_event(update: dict) -> Tuple:
         update["relationships"]["trip"]["data"]["id"],
         update["attributes"]["label"],
         updated_at,
+        vehicle_consist,
     )
 
 
@@ -87,6 +92,7 @@ def process_event(update, trips_state: TripsStateManager):
         trip_id,
         vehicle_label,
         updated_at,
+        vehicle_consist,
     ) = reduce_update_event(update)
 
     # Skip events where the vehicle has no stop associated
@@ -142,6 +148,7 @@ def process_event(update, trips_state: TripsStateManager):
                         "vehicle_label": vehicle_label,
                         "event_type": event_type,
                         "event_time": updated_at,
+                        "vehicle_consist": vehicle_consist,
                     }
                 ],
                 index=[0],
@@ -158,6 +165,7 @@ def process_event(update, trips_state: TripsStateManager):
             "stop_id": stop_id,
             "updated_at": updated_at,
             "event_type": event_type,
+            "vehicle_consist": vehicle_consist,
         },
     )
 

--- a/src/tests/test_trip_state.py
+++ b/src/tests/test_trip_state.py
@@ -18,6 +18,7 @@ class TestTripStatePerformance(unittest.TestCase):
             "stop_id": "123",
             "updated_at": datetime.now(EASTERN_TIME),
             "event_type": "ARR",
+            "vehicle_consist": "0704|0705|0790|0791|0749|0748",
         }
         state.trips["trip_123"] = trip_state
 
@@ -114,6 +115,7 @@ class TestTripStateFileIO(unittest.TestCase):
             "stop_id": "123",
             "updated_at": datetime.now(EASTERN_TIME),
             "event_type": "ARR",
+            "vehicle_consist": "0704|0705|0790|0791|0749|0748",
         }
 
         state.set_trip_state("trip_123", trip_state)

--- a/src/trip_state.py
+++ b/src/trip_state.py
@@ -24,6 +24,8 @@ class TripState(TypedDict):
     updated_at: datetime
     # What type of event was this? (ARR or DEP)
     event_type: str
+    # What vehicle numbers are included? Will be a pipe delimited string for vehicles with multiple carriages.
+    vehicle_consist: str
 
 
 def serialize_trip_state(trip_state: TripState) -> Dict[str, str]:


### PR DESCRIPTION
Modified code to add vehicle_consist to CSV output. The vehicle numbers are concatenated with pipe separators where vehicles have multiple carriage label values such as "0704|0705|0790|0791|0749|0748". Vehicles with a single carriage or no carriages will have vehicle_consist as a single string such as 0704. 