### PR TITLE
Added occupancy_status and occupancy_percentage

### DIFF
--- a/src/disk.py
+++ b/src/disk.py
@@ -26,6 +26,8 @@ CSV_FIELDS = [
     "scheduled_headway",
     "scheduled_tt",
     "vehicle_consist",
+    "occupancy_status",
+    "occupancy_percentage",
 ]
 DATA_DIR = pathlib.Path("data")
 STATE_FILENAME = "state.json"

--- a/src/event.py
+++ b/src/event.py
@@ -55,8 +55,23 @@ def reduce_update_event(update: dict) -> Tuple:
     updated_at = datetime.fromisoformat(update["attributes"]["updated_at"])
     if len(update["attributes"]["carriages"]) > 0:
         vehicle_consist = "|".join([carriage["label"] for carriage in update["attributes"]["carriages"]])
+        if update["attributes"]["carriages"][0]["occupancy_status"] is not None:
+            occupancy_status = "|".join(
+                [carriage["occupancy_status"] for carriage in update["attributes"]["carriages"]]
+            )
+        else:
+            occupancy_status = None
+
+        if update["attributes"]["carriages"][0]["occupancy_percentage"] is not None:
+            occupancy_percentage = "|".join(
+                [str(carriage["occupancy_percentage"]) for carriage in update["attributes"]["carriages"]]
+            )
+        else:
+            occupancy_percentage = None
     else:
         vehicle_consist = update["attributes"]["label"]
+        occupancy_status = update["attributes"]["occupancy_status"]
+        occupancy_percentage = None
 
     try:
         # The vehicle’s current (when current_status is STOPPED_AT) or next stop.
@@ -76,6 +91,8 @@ def reduce_update_event(update: dict) -> Tuple:
         update["attributes"]["label"],
         updated_at,
         vehicle_consist,
+        occupancy_status,
+        occupancy_percentage,
     )
 
 
@@ -93,6 +110,8 @@ def process_event(update, trips_state: TripsStateManager):
         vehicle_label,
         updated_at,
         vehicle_consist,
+        occupancy_status,
+        occupancy_percentage,
     ) = reduce_update_event(update)
 
     # Skip events where the vehicle has no stop associated
@@ -149,6 +168,8 @@ def process_event(update, trips_state: TripsStateManager):
                         "event_type": event_type,
                         "event_time": updated_at,
                         "vehicle_consist": vehicle_consist,
+                        "occupancy_status": occupancy_status,
+                        "occupancy_percentage": occupancy_percentage,
                     }
                 ],
                 index=[0],
@@ -166,6 +187,8 @@ def process_event(update, trips_state: TripsStateManager):
             "updated_at": updated_at,
             "event_type": event_type,
             "vehicle_consist": vehicle_consist,
+            "occupancy_status": occupancy_status,
+            "occupancy_percentage": occupancy_percentage,
         },
     )
 

--- a/src/trip_state.py
+++ b/src/trip_state.py
@@ -26,6 +26,10 @@ class TripState(TypedDict):
     event_type: str
     # What vehicle numbers are included? Will be a pipe delimited string for vehicles with multiple carriages.
     vehicle_consist: str
+    # Track Occupancy as available
+    occupancy_status: str | None
+    # Occupancy Percentage only available on Orange Line
+    occupancy_percentage: str | None
 
 
 def serialize_trip_state(trip_state: TripState) -> Dict[str, str]:


### PR DESCRIPTION
This adds occupancy status and percentage where applicable into the output CSV. 

The motivation is that this data could be shown in the tooltip on the data dashboard, This could help users understand the level of crowding on that particular train, which may impact: 

1. Excessive dwell times due to overcrowding and door blockage issues
2. Buses departing sooner because they are at crush capacity
3. Other potential patterns of note
